### PR TITLE
server: add --address argument

### DIFF
--- a/server/mpv_remote_app/__init__.py
+++ b/server/mpv_remote_app/__init__.py
@@ -26,6 +26,9 @@ def parse_args():
     parser.add_argument("-p", "--port", metavar="PORT_NUMBER", type=int,
                         default=28899,
                         help="Port number on which to listen (default: 28899)")
+    parser.add_argument("-a", "--address", metavar="ADDRESS", type=str,
+                        default="0.0.0.0",
+                        help="Address to bind to")
     parser.add_argument("-s", "--mpv-socket", metavar="SOCK", type=str,
                         default=None,
                         help="Unix socket that mpv is listening on (default: auto detect)")
@@ -98,7 +101,7 @@ def main():
             "--input-ipc-server="+args.mpv_socket, "--idle"])
 
     logging.debug(f"using mpv socket {args.mpv_socket}")
-    ms = MediaServer(args.port, args.password, root=args.root,
+    ms = MediaServer(args.port, args.address, args.password, root=args.root,
             no_hidden=not args.hidden, filetypes=args.filetypes,
             controller=MpvController(args.mpv_socket))
     ms.run(daemon=args.daemon)

--- a/server/mpv_remote_app/media_server.py
+++ b/server/mpv_remote_app/media_server.py
@@ -12,8 +12,9 @@ from collections import OrderedDict
 from os.path import abspath, realpath, join, isdir, isfile
 
 class MediaServer:
-    def __init__(self, port, password, root=os.getcwd(), no_hidden=True, filetypes=None, controller=None):
+    def __init__(self, port, address, password, root=os.getcwd(), no_hidden=True, filetypes=None, controller=None):
         self.port = port                # port to listen on
+        self.address = address          # address to bind to
         self.password = password        # server secret
         self.root = abspath(realpath(root)) # top level directory of server
         self.no_hidden = no_hidden      # send / play hidden files
@@ -37,7 +38,7 @@ class MediaServer:
         logging.debug("opening server")
         # create socket
         self.sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-        self.sock.bind(('0.0.0.0', self.port))
+        self.sock.bind((self.address, self.port))
         return self
     # runs the server
     def run(self, daemon=False):


### PR DESCRIPTION
This adds the option to purposely select an address for the server to bind to.
This can be used to run the server only on a specific interface (i.e. local LAN).
Usage: either `--address`/`-a` and the IP.
When unspecified it remains `0.0.0.0`