### PR TITLE
android: upgraded gradle and dependencies

### DIFF
--- a/MpvRemote/app/build.gradle
+++ b/MpvRemote/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    buildToolsVersion '30.0.3'
     defaultConfig {
         applicationId "miccah.mpvremote"
         minSdkVersion 15
@@ -20,11 +20,11 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    androidTestImplementation('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    compile 'com.android.support:appcompat-v7:25.1.0'
-    compile 'com.android.support:design:25.1.0'
-    testCompile 'junit:junit:4.12'
+    implementation 'com.android.support:appcompat-v7:25.1.0'
+    implementation 'com.android.support:design:25.1.0'
+    testImplementation 'junit:junit:4.12'
 }

--- a/MpvRemote/build.gradle
+++ b/MpvRemote/build.gradle
@@ -2,10 +2,14 @@
 
 buildscript {
     repositories {
-        jcenter()
+        google()
+        mavenCentral()
+        maven {
+            url 'https://maven.google.com'
+        }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:4.2.2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -14,7 +18,11 @@ buildscript {
 
 allprojects {
     repositories {
-        jcenter()
+        google()
+        mavenCentral()
+        maven {
+            url 'https://maven.google.com'
+        }
     }
 }
 

--- a/MpvRemote/gradle/wrapper/gradle-wrapper.properties
+++ b/MpvRemote/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Dec 28 10:00:20 PST 2015
+#Fri Jul 23 19:38:15 IDT 2021
 distributionBase=GRADLE_USER_HOME
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.1.1-bin.zip
 distributionPath=wrapper/dists
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
This Android project's gradle version is very old, where the very recent Android Studio 4.2.2 refuses to even work with.
I've selected the minimum possible gradle version (4.8.1) and also had to introduce maven repo for some of its dependencies.
Please consider upgrading (with dependencies as well !) so people don't have hard time joining the development effort