### PR TITLE
android: crashing bug fixes

### DIFF
--- a/MpvRemote/app/src/main/java/miccah/laptopremote/SettingsAdapter.java
+++ b/MpvRemote/app/src/main/java/miccah/laptopremote/SettingsAdapter.java
@@ -59,7 +59,7 @@ public class SettingsAdapter extends BaseAdapter {
             new UDPPacket(ipAddr, Settings.port, Settings.passwd, new Callback() {
                 public void callback(boolean result, JSONObject obj) {
                     String addr = Settings.ipAddress;
-                    boolean notFound = addr.charAt(addr.length() - 1) == '.';
+                    boolean notFound = (addr.length() > 0) ? addr.charAt(addr.length() - 1) == '.' : false;
                     if (result && notFound) {
                         Settings.ipAddress = ipAddr;
                         myItems.get(1).caption = Settings.ipAddress;

--- a/MpvRemote/app/src/main/java/miccah/laptopremote/SettingsAdapter.java
+++ b/MpvRemote/app/src/main/java/miccah/laptopremote/SettingsAdapter.java
@@ -247,7 +247,7 @@ public class SettingsAdapter extends BaseAdapter {
         }
         else if (hint.equals(myItems.get(2).hint)) {
             // Port
-            Settings.port = Integer.parseInt(value);
+            Settings.port = value.matches("\\d+") ?  Integer.parseInt(value) : 0;
         }
         else if (hint.equals(myItems.get(4).hint)) {
             // Password


### PR DESCRIPTION
The android app crashes when the focus changes after clearing the IP address edit box.
It also crashes focusing away from the port when it was cleared or not set to an integer.
I've added basic tests to the relevant lines.
Probably more testing is needed for these and other fields.