### PR TITLE
android: disable RTL

### DIFF
--- a/MpvRemote/app/src/main/AndroidManifest.xml
+++ b/MpvRemote/app/src/main/AndroidManifest.xml
@@ -10,7 +10,7 @@
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
-        android:supportsRtl="true"
+        android:supportsRtl="false"
         android:theme="@style/AppTheme" >
         <activity
             android:name=".MainActivity"


### PR DESCRIPTION
Since there are no layouts to handle RTL layouts / translated strings there is no point in keeping this setting. It actually makes the interface appearance worse for users of RTL enabled androids (for example, the rewind and forward buttons switch places).

When RTL is actually introduced this should be re-enabled.