### PR TITLE
android: hide soft keyboard on EditText focus loss

### DIFF
--- a/MpvRemote/app/src/main/java/miccah/laptopremote/MainActivity.java
+++ b/MpvRemote/app/src/main/java/miccah/laptopremote/MainActivity.java
@@ -1,14 +1,19 @@
 package miccah.mpvremote;
 
 import android.app.Activity;
+import android.content.Context;
+import android.graphics.Rect;
 import android.os.Bundle;
 import android.support.v4.app.ActionBarDrawerToggle;
 import android.support.v4.widget.DrawerLayout;
+import android.util.Log;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.View;
 import android.view.KeyEvent;
 import android.view.MotionEvent;
+import android.view.inputmethod.InputMethodManager;
+import android.widget.EditText;
 import android.widget.ListView;
 import android.widget.LinearLayout;
 import android.widget.Toast;
@@ -126,6 +131,23 @@ public class MainActivity extends Activity {
         ((BackgroundImageButton)findViewById(R.id.full_screen)).
             setDrawables(R.drawable.vector_arrange_below_off,
                          R.drawable.vector_arrange_below_on);
+    }
+
+    @Override
+    public boolean dispatchTouchEvent(MotionEvent event) {
+        if (event.getAction() == MotionEvent.ACTION_DOWN) {
+            View v = getCurrentFocus();
+            if ( v instanceof EditText) {
+                Rect outRect = new Rect();
+                v.getGlobalVisibleRect(outRect);
+                if (!outRect.contains((int)event.getRawX(), (int)event.getRawY())) {
+                    v.clearFocus();
+                    InputMethodManager imm = (InputMethodManager) getSystemService(Context.INPUT_METHOD_SERVICE);
+                    imm.hideSoftInputFromWindow(v.getWindowToken(), 0);
+                }
+            }
+        }
+        return super.dispatchTouchEvent(event);
     }
 
     @Override


### PR DESCRIPTION
This makes sure to hide the keyboard when the user touches outside a EditText or the keyboard itself.

Solves the visibility issue from #34 