### PR TITLE
android: use fullscreen icon instead of copy

### DIFF
--- a/MpvRemote/app/src/main/java/miccah/laptopremote/MainActivity.java
+++ b/MpvRemote/app/src/main/java/miccah/laptopremote/MainActivity.java
@@ -124,8 +124,8 @@ public class MainActivity extends Activity {
             setDrawables(android.R.drawable.ic_media_pause,
                          android.R.drawable.ic_media_play);
         ((BackgroundImageButton)findViewById(R.id.full_screen)).
-            setDrawables(R.drawable.vector_arrange_below_off,
-                         R.drawable.vector_arrange_below_on);
+            setDrawables(R.drawable.fullscreen,
+                         R.drawable.fullscreen_exit);
     }
 
     @Override

--- a/MpvRemote/app/src/main/res/drawable/fullscreen.xml
+++ b/MpvRemote/app/src/main/res/drawable/fullscreen.xml
@@ -4,5 +4,5 @@
     android:width="24dp"
     android:viewportWidth="24"
     android:viewportHeight="24">
-    <path android:fillColor="#000" android:pathData="M5,5H10V7H7V10H5V5M14,5H19V10H17V7H14V5M17,14H19V19H14V17H17V14M10,17V19H5V14H7V17H10Z" />
+    <path android:fillColor="#FFF" android:pathData="M5,5H10V7H7V10H5V5M14,5H19V10H17V7H14V5M17,14H19V19H14V17H17V14M10,17V19H5V14H7V17H10Z" />
 </vector>

--- a/MpvRemote/app/src/main/res/drawable/fullscreen_exit.xml
+++ b/MpvRemote/app/src/main/res/drawable/fullscreen_exit.xml
@@ -4,5 +4,5 @@
     android:width="24dp"
     android:viewportWidth="24"
     android:viewportHeight="24">
-    <path android:fillColor="#000" android:pathData="M14,14H19V16H16V19H14V14M5,14H10V19H8V16H5V14M8,5H10V10H5V8H8V5M19,8V10H14V5H16V8H19Z" />
+    <path android:fillColor="#FFF" android:pathData="M14,14H19V16H16V19H14V14M5,14H10V19H8V16H5V14M8,5H10V10H5V8H8V5M19,8V10H14V5H16V8H19Z" />
 </vector>

--- a/MpvRemote/app/src/main/res/layout/activity_main.xml
+++ b/MpvRemote/app/src/main/res/layout/activity_main.xml
@@ -88,7 +88,7 @@
             android:layout_centerHorizontal="true" />
 
         <miccah.mpvremote.BackgroundImageButton
-            android:src="@drawable/vector_arrange_below_off"
+            android:src="@drawable/fullscreen"
             android:id="@+id/full_screen"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"


### PR DESCRIPTION
I've noticed there's a fullscreen icon set (on&off) already bundled in.
So why not use that instead of the "copy file" (paper on paper) one ?
I changed the foreground color to white so it can be seen.
It is much more explanatory towards a new user if you ask me.