### PR TITLE
Change sidebar button color to white

### DIFF
--- a/MpvRemote/app/src/main/res/drawable/menu.xml
+++ b/MpvRemote/app/src/main/res/drawable/menu.xml
@@ -4,5 +4,5 @@
     android:width="24dp"
     android:viewportWidth="24"
     android:viewportHeight="24">
-    <path android:fillColor="#333" android:pathData="M3,6H21V8H3V6M3,11H21V13H3V11M3,16H21V18H3V16Z" />
+    <path android:fillColor="#FFF" android:pathData="M3,6H21V8H3V6M3,11H21V13H3V11M3,16H21V18H3V16Z" />
 </vector>


### PR DESCRIPTION
![white](https://user-images.githubusercontent.com/31196036/126977945-0f821f81-860c-4c43-a43e-f67f5f931b9d.png)
This changes the left grayed button into white (#FFF) to fit with the entire theme and not look like it's disabled/pressed when it's not.