### PR TITLE
limited windows support

### DIFF
--- a/server/mpv_remote_app/__init__.py
+++ b/server/mpv_remote_app/__init__.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python3
 import os
+import sys
 import psutil
 import logging
 import argparse
@@ -8,6 +9,8 @@ import subprocess
 from .media_server import MediaServer
 from .media_controllers import MpvController
 from os.path import abspath, realpath, isdir, join
+if sys.platform == 'win32':
+    from .windows_monkeypatch import *
 
 name = "mpv_remote_app"
 

--- a/server/mpv_remote_app/windows_monkeypatch.py
+++ b/server/mpv_remote_app/windows_monkeypatch.py
@@ -1,0 +1,31 @@
+# no AF_UNIX sockets for windows
+# looking forward to https://bugs.python.org/issue33408
+# using a monkeypatch for now
+import win32pipe
+from .media_controllers import MpvController, MediaController
+
+
+class PipeMediaController(MediaController):
+    def __init__(self, pipename):
+        super().__init__()
+        self.pipename = pipename
+        self.last_answer = ''
+
+    def send(self, message):
+        self.last_answer = win32pipe.CallNamedPipe(
+            self.pipename, 
+            message.encode(), 
+            1024, 
+            100,
+        )
+        return len(self.last_answer) != 0
+
+    def recv(self, timeout=None):
+        return self.last_answer.decode()
+
+
+MpvController.__bases__ = (PipeMediaController, )
+# `show_property` commands have no response from mpv (https://mpv.io/manual/master/#socat-example)
+# CallNamedPipe hangs indefinitely awaiting for a response despite a specified timeout
+# thus removing `show_property` method
+MpvController.show_property = lambda self, property, pre=None, post='', duration=1000: None


### PR DESCRIPTION
As mpv manual states, it supports ipc on windows via Named Pipes (https://mpv.io/manual/master/#command-prompt-example).
This PR checks for win32-platform on init and applies a monkeypatch to `MpvController` making it inherited from new `PipeMediaController`. Its `send` method relies on `win32pipe.CallNamedPipe` instead of unix socket, call result is kept internally in `self.last_answer` as a dirty solution to keep separated send/recv interface.

Closes #32 and closes #36.

**Issues:**
Mpv has no response on `show_property` commands, it blocks `win32pipe.CallNamedPipe` call indefinitely ignoring timeout, had to monkeypatch `show_property` method to prevent that

**Example:**
```
mpv-remote-app -s "\\.\pipe\mpv-pipe" password
```