### PR TITLE
Allow to search and play a ytdl:// stream

### DIFF
--- a/MpvRemote/app/src/main/java/miccah/mpvremote/MainActivity.java
+++ b/MpvRemote/app/src/main/java/miccah/mpvremote/MainActivity.java
@@ -137,6 +137,20 @@ public class MainActivity extends Activity {
         ((BackgroundImageButton)findViewById(R.id.full_screen)).
             setDrawables(R.drawable.fullscreen,
                          R.drawable.fullscreen_exit);
+
+        /* Setup ytsearch callback */
+        EditText et = (EditText) findViewById(R.id.ytsearch);
+        et.setOnKeyListener(new View.OnKeyListener() {
+            @Override
+            public boolean onKey(View v, int keyCode, KeyEvent event) {
+                if (keyCode == KeyEvent.KEYCODE_ENTER && event.getAction() == KeyEvent.ACTION_UP) {
+                    ytsearchEntered(et.getText().toString());
+                    return true;
+                }
+                return false;
+            }
+        });
+
     }
 
     @Override
@@ -241,6 +255,9 @@ public class MainActivity extends Activity {
     }
     public void settingsButton(View view) {
         mDrawerLayout.openDrawer(Settings.mDrawerList);
+    }
+    public void ytsearchEntered(String ytsearch) {
+        sendCommand(null, "play", "path", "ytdl://ytsearch:" + ytsearch);
     }
 
     private void sendCommand(Callback cb, String command, Object... pairs) {

--- a/MpvRemote/app/src/main/res/layout/activity_main.xml
+++ b/MpvRemote/app/src/main/res/layout/activity_main.xml
@@ -109,6 +109,15 @@
             android:src="@drawable/menu"
             android:onClick="settingsButton" />
 
+        <EditText
+            android:id="@+id/ytsearch"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_below="@id/settings"
+            android:ems="10"
+            android:hint="ytsearch"
+            android:inputType="text" />
+
     </RelativeLayout>
 
     <!-- The navigation drawer -->

--- a/server/mpv_remote_app/media_server.py
+++ b/server/mpv_remote_app/media_server.py
@@ -148,12 +148,12 @@ class MediaServer:
             ret, msg = False, None
             if command == "play":
                 path = join(self.root, cmd["path"])
-                if path[:len(self.root)] != self.root:
-                    # outside of root
-                    ret, msg = False, "Path out of bounds"
-                elif not isfile(path):
-                    # not a file
-                    ret, msg  = False, "%s is not a file" % cmd["path"]
+                if not isfile(path):
+                    # not a file, perhaps a URI
+                    if cmd["path"].startswith("ytdl://"):
+                        ret = self.controller.play(cmd["path"])
+                    else:
+                        ret, msg  = False, "%s is neither a file nor a valid URI" % cmd["path"]
                 else:
                     # play the file
                     ret = self.controller.play(abspath(realpath(path)))


### PR DESCRIPTION
Closes #10 

When this PR is merged a user can play a yt video on the remote server from within the app.

A new text box is added on the main activity. Through this search box the user can play a video by either
- entering some keywords
- pasting the full URL of the video
- or pasting just the yt video id

The ytdl:// protocol handler in mpv takes care of parsing the search string and selecting the right video.

![image](https://user-images.githubusercontent.com/26487222/184541739-c0a55638-2900-4ad4-ba90-9dd952c8719f.png)
